### PR TITLE
Let's use 'warn' instead of 'off'

### DIFF
--- a/index.js
+++ b/index.js
@@ -12,7 +12,7 @@ module.exports = (results) => {
   const sortedRuleIds = Object.keys(rules).sort();
 
   const overrides = sortedRuleIds.map((ruleId) => ({
-    rules: { [ruleId]: 'off' },
+    rules: { [ruleId]: 'warn' },
     files: [...new Set(rules[ruleId])].sort(),
   }));
 


### PR DESCRIPTION
Over time we've decided to change all of these to `warn` so that users see the patterns we have deprecated. We recently started using this tool again and it re-set all the todo to off.